### PR TITLE
Re-add sha256 storage support

### DIFF
--- a/cortextool/provider.go
+++ b/cortextool/provider.go
@@ -17,6 +17,8 @@ func init() {
 	schema.DescriptionKind = schema.StringMarkdown
 }
 
+var storeRulesSha256 bool
+
 // New returns a newly created provider
 func New(version string, cortexClient *CortexRuleClient) func() *schema.Provider {
 	return func() *schema.Provider {
@@ -75,6 +77,12 @@ func New(version string, cortexClient *CortexRuleClient) func() *schema.Provider
 					DefaultFunc: schema.EnvDefaultFunc("CORTEXTOOL_INSECURE_SKIP_VERIFY", nil),
 					Description: "Skip TLS certificate verification. May alternatively be set via the `CORTEXTOOL_INSECURE_SKIP_VERIFY` environment variable.",
 				},
+				"store_rules_sha256": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					DefaultFunc: schema.EnvDefaultFunc("CORTEXTOOL_STORE_RULES_SHA256", false),
+					Description: "Set to true if you want to save only the sha256sum instead of namespace's groups rules definition in the tfstate. May alternatively be set via the `CORTEXTOOL_STORE_RULES_SHA256` environment variable.",
+				},
 			},
 			DataSourcesMap: map[string]*schema.Resource{},
 			ResourcesMap: map[string]*schema.Resource{
@@ -105,6 +113,8 @@ func configure(version string, p *schema.Provider, cortexClient *CortexRuleClien
 			}
 			c.cli = &cc
 		}
+
+		storeRulesSha256 = d.Get("store_rules_sha256").(bool)
 
 		return c, diags
 	}

--- a/cortextool/testdata/rules-fails-check.yaml
+++ b/cortextool/testdata/rules-fails-check.yaml
@@ -1,6 +1,0 @@
-groups:
-- name: mimir_api_1
-  rules:
-  - expr: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-      by (le, cluster, job))
-    record: cluster_job_cortex_request_duration_seconds_99quantile

--- a/cortextool/testdata/rules-parse-error.yaml
+++ b/cortextool/testdata/rules-parse-error.yaml
@@ -1,6 +1,0 @@
-groups:
-- name: mimir_api_1
-  rules:
-  - expression: histogram_quantile(0.99, sum(rate(cortex_request_duration_seconds_bucket[1m]))
-      by (le, cluster, job))
-    record: cluster_job_cortex_request_duration_seconds_99quantile

--- a/cortextool/testdata/rules2_whitespace.yaml
+++ b/cortextool/testdata/rules2_whitespace.yaml
@@ -1,0 +1,12 @@
+namespace: grafana-agent-traces
+groups:
+  - name: grafana-agent
+    rules:
+      - alert: LogWarnMessages
+        expr: |
+          sum(
+            rate( {deployment="grafana-agent-traces"} |= `level=warn` [1m] )
+          ) > 0.1
+        for: 5m
+        labels:
+          team: sre

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,7 @@ provider "cortextool" {
 - `api_key` (String, Sensitive) API key to use when contacting Grafana Loki. May alternatively be set via the `CORTEXTOOL_API_KEY` environment variable.
 - `api_user` (String) API user to use when contacting Grafana Loki. May alternatively be set via the `CORTEXTOOL_API_USER` environment variable.
 - `insecure_skip_verify` (Boolean) Skip TLS certificate verification. May alternatively be set via the `CORTEXTOOL_INSECURE_SKIP_VERIFY` environment variable.
+- `store_rules_sha256` (Boolean) Set to true if you want to save only the sha256sum instead of namespace's groups rules definition in the tfstate. May alternatively be set via the `CORTEXTOOL_STORE_RULES_SHA256` environment variable.
 - `tenant_id` (String) Tenant ID to use when contacting Grafana Loki. May alternatively be set via the `CORTEXTOOL_TENANT_ID` environment variable.
 - `tls_ca_path` (String) Certificate CA bundle to use to verify the Loki server's certificate. May alternatively be set via the `CORTEXTOOL_TLS_CA_PATH` environment variable.
 - `tls_cert_path` (String) Client TLS certificate file to use to authenticate to the Loki server. May alternatively be set via the `CORTEXTOOL_TLS_CERT_PATH` environment variable.


### PR DESCRIPTION
Supports storing as sha256 to reduce statefile size. In this mode, change detection is less resilient since Loki built-in logical `CompareNamespaces` can't be used to suppress non-functional changes